### PR TITLE
ERD-2059 add RaiseOperatorError service for operator-facing AMAS errors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,6 +44,7 @@ add_service_files(
   ControlManager.srv
   CortexConfigurationInfo.srv
   SafetyParameter.srv
+  RaiseOperatorError.srv
 )
 
 add_action_files(

--- a/srv/RaiseOperatorError.srv
+++ b/srv/RaiseOperatorError.srv
@@ -1,0 +1,8 @@
+# Raise an operator-facing error notification in the AMAS UI (service is served by AMAS over rosbridge).
+# Error codes are tracked in https://github.com/Extend-Robotics/unity_error_manager/blob/main/ErrorCodeList.md
+string source      # entity the error relates to, shown as the affected object in the AMAS error UI
+string code        # error code from ErrorCodeList.md, deduplicated together with source
+string definition  # short error title shown to the operator
+string resolution  # instructions telling the operator how to resolve the error
+---
+bool ack

--- a/srv/RaiseOperatorError.srv
+++ b/srv/RaiseOperatorError.srv
@@ -5,4 +5,4 @@ string code        # error code from ErrorCodeList.md, deduplicated together wit
 string definition  # short error title shown to the operator
 string resolution  # instructions telling the operator how to resolve the error
 ---
-bool ack
+bool ack           # true: accepted and queued for display (deduplicated while active); false: rejected (empty code/definition, or AMAS cannot deliver)

--- a/srv/RaiseOperatorError.srv
+++ b/srv/RaiseOperatorError.srv
@@ -1,7 +1,7 @@
 # Raise an operator-facing error notification in the AMAS UI (service is served by AMAS over rosbridge).
-# Error codes are tracked in https://github.com/Extend-Robotics/unity_error_manager/blob/main/ErrorCodeList.md
+# Error codes are tracked in docs/ErrorCodeList.md in the extend_unity_release repo
 string source      # entity the error relates to, shown as the affected object in the AMAS error UI
-string code        # error code from ErrorCodeList.md, deduplicated together with source
+string code        # error code from ErrorCodeList.md (RR range), deduplicated together with source while active
 string definition  # short error title shown to the operator
 string resolution  # instructions telling the operator how to resolve the error
 ---


### PR DESCRIPTION
## What

New `RaiseOperatorError.srv`, served by AMAS over rosbridge so any robot-side node can raise an operator-facing error in the AMAS UI with one service call. Fields map 1:1 onto AMAS's `ErrorProtocol` (`source`/`code`/`definition`/`resolution` → bool `ack`). No severity field — `ErrorProtocol` has none.

`ack` semantics are documented in the srv: `true` = accepted and queued for display (deduplicated while active); `false` = rejected (empty code/definition, or AMAS cannot deliver).

## Companion PR

- extend_unity_release [#1003](https://github.com/Extend-Robotics/extend_unity_release/pull/1003): RosSharp service server advertising `raise_operator_error` (base `URDF_test`). Also hosts `docs/ErrorCodeList.md` (moved from the deprecated unity_error_manager repo) with the reserved `RR` code range.

Jira: https://extend-robotics.atlassian.net/browse/ERD-2059

## Verification

- `colcon_build_no_deps extend_msgs` passes.
- `rossrv show extend_msgs/RaiseOperatorError` resolves with the expected fields.